### PR TITLE
chore: update extension name in readme

### DIFF
--- a/app-extension/README.md
+++ b/app-extension/README.md
@@ -10,7 +10,7 @@ quasar-app-extension-dotenv is a `CLI App Extension` for [Quasar Framework](http
 
 # Install
 ```bash
-quasar ext add dotenv
+quasar ext add @quasar/dotenv
 ```
 Quasar CLI will retrieve it from NPM and install the extension.
 
@@ -44,7 +44,7 @@ Then you will need to use the `parseInt()` function as it will be propogated to 
 
 # Uninstall
 ```bash
-quasar ext remove dotenv
+quasar ext remove @quasar/dotenv
 ```
 
 # Donate


### PR DESCRIPTION
Running `quasar ext add dotenv` will attempt to install the `quasar-app-extension-dotenv` package from NPM, which no longer exists. Looks like it's been moved to the quasar organization. `quasar ext add @quasar/dotenv` will install the correct package and run the cli prompts.

README updated to reflect this change